### PR TITLE
Fix missing cryptography modules

### DIFF
--- a/1.8.7-p374
+++ b/1.8.7-p374
@@ -67,6 +67,7 @@ if type -p brew >/dev/null; then
   package_option ruby configure --with-openssl-dir="$(brew --prefix basecamp/dev/openssl@1.0)"
 else
   install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
+  package_option ruby configure --with-openssl-dir="$PREFIX_PATH/openssl"
 fi
 
 require_gcc

--- a/1.9.3-p551
+++ b/1.9.3-p551
@@ -44,7 +44,11 @@ if type -p brew >/dev/null; then
   brew install basecamp/dev/openssl@1.0
   package_option ruby configure --with-openssl-dir="$(brew --prefix basecamp/dev/openssl@1.0)"
 else
+  # Install OpenSSL 1.0.2u (Ruby 1.9.3 is incompatible with OpenSSL 1.1+)
   install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
+  # Tell Ruby where to find OpenSSL and embed rpath so libraries are found at runtime
+  export LDFLAGS="-L$PREFIX_PATH/openssl/lib -Wl,-rpath,$PREFIX_PATH/openssl/lib"
+  RUBY_CONFIGURE_OPTS="${RUBY_CONFIGURE_OPTS:-} --with-openssl-dir=$PREFIX_PATH/openssl"
 fi
 
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml

--- a/1.9.3-p551
+++ b/1.9.3-p551
@@ -44,11 +44,8 @@ if type -p brew >/dev/null; then
   brew install basecamp/dev/openssl@1.0
   package_option ruby configure --with-openssl-dir="$(brew --prefix basecamp/dev/openssl@1.0)"
 else
-  # Install OpenSSL 1.0.2u (Ruby 1.9.3 is incompatible with OpenSSL 1.1+)
   install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-  # Tell Ruby where to find OpenSSL and embed rpath so libraries are found at runtime
-  export LDFLAGS="-L$PREFIX_PATH/openssl/lib -Wl,-rpath,$PREFIX_PATH/openssl/lib"
-  RUBY_CONFIGURE_OPTS="${RUBY_CONFIGURE_OPTS:-} --with-openssl-dir=$PREFIX_PATH/openssl"
+  package_option ruby configure --with-openssl-dir="$PREFIX_PATH/openssl"
 fi
 
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
@@ -59,7 +56,7 @@ export CFLAGS="$RUBY_CFLAGS"
 
 build_package_standard_serial() {
   local package_name="$1"
-  { ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS
+  { ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS "${RUBY_CONFIGURE_OPTS_ARRAY[@]}"
     make -j1
     make install
   } >&4 2>&1

--- a/test/build
+++ b/test/build
@@ -72,6 +72,15 @@ build_image() {
   fi
 }
 
+# Default post-flight checks - can be overridden via test/verify/<version>
+default_verify_script() {
+  cat <<'VERIFY'
+/opt/ruby/bin/ruby -e 'require "openssl"; puts "openssl: #{OpenSSL::OPENSSL_VERSION}"'
+/opt/ruby/bin/ruby -e 'require "digest/sha2"; puts "digest: ok"'
+/opt/ruby/bin/ruby -e 'require "zlib"; puts "zlib: ok"'
+VERIFY
+}
+
 test_ruby() {
   local platform=$1
   local version=$2
@@ -83,13 +92,29 @@ test_ruby() {
 
   printf "  %-14s %-14s " "$platform" "$version"
 
-  if output=$(docker run --rm $platform_flag "$image" bash -c \
-    "ruby-build $version /opt/ruby && /opt/ruby/bin/ruby --version" 2>&1); then
+  # Use version-specific verify script if it exists, otherwise use defaults
+  local verify_script
+  if [[ -f "test/verify/$version" ]]; then
+    verify_script=$(cat "test/verify/$version")
+  else
+    verify_script=$(default_verify_script)
+  fi
+
+  # Build Ruby and run post-flight checks
+  local build_script="
+    set -e
+    ruby-build $version /opt/ruby
+    /opt/ruby/bin/ruby --version
+    $verify_script
+  "
+
+  if output=$(docker run --rm $platform_flag "$image" bash -c "$build_script" 2>&1); then
     ruby_version=$(echo "$output" | grep -o 'ruby [0-9].*\]' | tail -1)
     echo "✓  $ruby_version"
     return 0
   else
     echo "✗  FAILED"
+    echo "$output" | tail -20
     return 1
   fi
 }


### PR DESCRIPTION
After compilation, on Arch Linux, Ruby 1.9.3 can't find OpenSSL and disables all cryptography modules.
This PR changes the loadpaths of the build binary on Linux to fix that issue.